### PR TITLE
docs(readme): fontScale added to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,6 +963,7 @@ You can reorder, remove, or add hints. For example, to replace emoji with notes:
 | **Appearance** | `backgroundTransparency` | `0.2` | Background transparency (0-1) |
 | | `launcherXRatio` | `0.5` | Horizontal position (0=left, 1=right) |
 | | `launcherYRatio` | `0.1` | Vertical position (0=top, 1=bottom) |
+| | `fontScale` | `1` | Font scaling factor  (0.75=min, 1.5=max) |
 | **Sizes** | `searchWidth` | `580` | Search bar width (px) |
 | | `maxResultsHeight` | `600` | Max results container height (px) |
 | **Paths** | `wallpaperDir` | `""` | Custom wallpaper directory (empty = ~/Pictures/Wallpapers) |


### PR DESCRIPTION
Changes:
- Added the documentation for the `fontScale` property into the README

I have installed `hamr` a few days ago. The size of the launcher is too tiny for me, so I started looking if I can contribute with adding scaling options. And as I was looking through project structure, I have noticed that change in this direction was made already.

Would also love to have more scaling discussion at #18 :)