### PR TITLE
Fix Nix build and calculator plugin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,10 +58,11 @@
         runtimeDeps = with pkgs; [
           python3
           pulseaudio  # Provides paplay for sound notifications
+          libqalculate  # For calculator plugin (qalc command)
 
           # Fonts required for UI
-          material-symbols-variable
-          jetbrains-mono-nf
+          material-symbols
+          nerd-fonts.jetbrains-mono
         ];
 
         # Common arguments for all crane derivations
@@ -88,12 +89,15 @@
           postInstall = ''
             mkdir -p $out/share/hamr
             cp -r ${./plugins} $out/share/hamr/plugins
+            chmod -R +w $out/share/hamr/plugins
           '';
 
           # Wrap binaries with runtime dependencies
           preFixup = ''
             gappsWrapperArgs+=(
               --prefix PATH : ${pkgs.lib.makeBinPath runtimeDeps}
+              --prefix XDG_DATA_DIRS : ${pkgs.material-symbols}/share
+              --prefix XDG_DATA_DIRS : ${pkgs.nerd-fonts.jetbrains-mono}/share
             )
           '';
 

--- a/plugins/calculate/handler.py
+++ b/plugins/calculate/handler.py
@@ -450,9 +450,6 @@ def main():
                                 "description": f"= {query}",
                                 "icon": "calculate",
                                 "verb": "Copy",
-                                "copy": result,
-                                "notify": f"Copied: {result}",
-                                "close": True,
                             }
                         ],
                         "inputMode": "realtime",


### PR DESCRIPTION
## Summary

Fixes several issues preventing `nix run github:Stewart86/hamr` from working:

- **Build failures**: Wrong font package names (`material-symbols-variable` → `material-symbols`, `jetbrains-mono-nf` → `nerd-fonts.jetbrains-mono`)
- **Build failure**: Plugins copied from store are read-only, causing `sed` to fail during Rust reference stripping. Added `chmod -R +w`.
- **Calculator broken**: Missing `libqalculate` dependency (provides `qalc` command)
- **Icons not rendering**: Added font paths to `XDG_DATA_DIRS` so fontconfig can discover them
- **Calculator UX bug**: Removed `copy`/`close` from search results - was auto-closing before user could finish typing expressions like `=1+1`

## Test plan

- [ ] `nix run github:nitwit-se/hamr#fix-nix-build` builds successfully
- [ ] App launches and icons render correctly
- [ ] Calculator plugin: type `=1+1`, press Enter → copies "2" to clipboard

Fixes #34